### PR TITLE
Add AP EPG QoS class variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   contract_consumers          = ["CON1"]
@@ -123,6 +124,7 @@ module "aci_endpoint_group" {
 | <a name="input_flood_in_encap"></a> [flood\_in\_encap](#input\_flood\_in\_encap) | Flood in encapsulation. | `bool` | `false` | no |
 | <a name="input_intra_epg_isolation"></a> [intra\_epg\_isolation](#input\_intra\_epg\_isolation) | Intra EPG isolation. | `bool` | `false` | no |
 | <a name="input_preferred_group"></a> [preferred\_group](#input\_preferred\_group) | Preferred group membership. | `bool` | `false` | no |
+| <a name="input_qos_class"></a> [qos\_class](#input\_qos\_class) | QoS class. | `string` | `unspecified` | no |
 | <a name="input_custom_qos_policy"></a> [custom\_qos\_policy](#input\_custom\_qos\_policy) | Custom QoS policy name. | `string` | `""` | no |
 | <a name="input_bridge_domain"></a> [bridge\_domain](#input\_bridge\_domain) | Bridge domain name. | `string` | n/a | yes |
 | <a name="input_contract_consumers"></a> [contract\_consumers](#input\_contract\_consumers) | List of contract consumers. | `list(string)` | `[]` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,6 +24,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   contract_consumers          = ["CON1"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,6 +10,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   contract_consumers          = ["CON1"]

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ resource "aci_rest_managed" "fvAEPg" {
     floodOnEncap = var.flood_in_encap == true ? "enabled" : "disabled"
     pcEnfPref    = var.intra_epg_isolation == true ? "enforced" : "unenforced"
     prefGrMemb   = var.preferred_group == true ? "include" : "exclude"
+    prio         = var.qos_class
   }
 }
 

--- a/tests/full/test_full.tf
+++ b/tests/full/test_full.tf
@@ -34,6 +34,7 @@ module "main" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   contract_consumers          = ["CON1"]
@@ -152,6 +153,12 @@ resource "test_assertions" "fvAEPg" {
     description = "prefGrMemb"
     got         = data.aci_rest_managed.fvAEPg.content.prefGrMemb
     want        = "include"
+  }
+
+  equal "qosClass" {
+    description = "qosClass"
+    got         = data.aci_rest_managed.fvAEPg.content.qosClass
+    want        = "level1"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,17 @@ variable "preferred_group" {
   default     = false
 }
 
+variable "qos_class" {
+  description = "QoS class."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^level[1-6]|unspecified$", var.qos_class))
+    error_message = "Allowed values are `level1` to `level6` and `unspecified`."
+  }
+}
+
 variable "custom_qos_policy" {
   description = "Custom QoS policy name."
   type        = string


### PR DESCRIPTION
The application profile endpoint group `qos_class`/ `prio`variable is missing.