### PR TITLE
Add support for Colon ":" in Static Binding Object Name #235

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -472,9 +472,9 @@ variable "static_ports" {
 
   validation {
     condition = alltrue([
-      for sp in var.static_ports : sp.channel == null || can(regex("^[a-zA-Z0-9_.-]{0,64}$", sp.channel))
+      for sp in var.static_ports : sp.channel == null || can(regex("^[a-zA-Z0-9_.-:]{0,64}$", sp.channel))
     ])
-    error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }
 
   validation {


### PR DESCRIPTION
aci.aci_endpoint_group:
var.static_ports : sp.channel - Static binding for PC/vPC object that includes colon - added colon ":"